### PR TITLE
FIxed error on downloading events for missing id

### DIFF
--- a/broker-client/pom.xml
+++ b/broker-client/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.openaire</groupId>
 		<artifactId>broker-cmdline-client</artifactId>
-		<version>1.1.1</version>
+		<version>1.1.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/broker-client/src/main/java/eu/dnetlib/broker/BrokerClient.java
+++ b/broker-client/src/main/java/eu/dnetlib/broker/BrokerClient.java
@@ -110,7 +110,9 @@ public class BrokerClient {
 			}
 
 			notCompleted = !data.get("completed").getAsBoolean();
-			url = baseUrl + "/scroll/notifications/" + data.get("id").getAsString();
+			if(notCompleted) {
+			    url = baseUrl + "/scroll/notifications/" + data.get("id").getAsString();
+			}
 
 		} while (notCompleted);
 

--- a/broker-cmdline/pom.xml
+++ b/broker-cmdline/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.openaire</groupId>
 		<artifactId>broker-cmdline-client</artifactId>
-		<version>1.1.1</version>
+		<version>1.1.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	
 	<groupId>eu.openaire</groupId>
 	<artifactId>broker-cmdline-client</artifactId>
-	<version>1.1.1</version>
+	<version>1.1.2</version>
 	<packaging>pom</packaging>
 
 	<name>broker-cmdline-client</name>


### PR DESCRIPTION
This PR fixes the issue https://github.com/openaire/broker-cmdline-client/issues/4
I added a check to read the id of the incoming response from the broker only if the completed flag is false.